### PR TITLE
[FIX] css: rendering of inline images

### DIFF
--- a/_extensions/odoo/static/mixins.less
+++ b/_extensions/odoo/static/mixins.less
@@ -54,3 +54,11 @@
 .shadow-5 {
   box-shadow: 0 15px 24px rgba(0, 0, 0, 0.22), 0 19px 76px rgba(0, 0, 0, 0.3);
 }
+
+// overwrite bootstrap inline forcing
+.img-responsive {
+  display: inline-block;
+}
+.img-responsive.center-block {
+  display: block;
+}


### PR DESCRIPTION
Bootstrap forces the img-responsive images to be a block.
IMHO bootstrap should be killed and burned with fire but them it appears I know
nothing (John Snow) about CSS and making things looks nice so they have probably
their reason to do so.
Anyway, not that I care, let me use inline images for Flupke sake!

Before (:-1: :cry:)
![screenshot from 2015-10-29 10-11-24](https://cloud.githubusercontent.com/assets/564822/10814334/a1cf0d56-7e25-11e5-8b52-3300438d89c6.png)

After (:+1: :tada:  )
![screenshot from 2015-10-29 10-12-29](https://cloud.githubusercontent.com/assets/564822/10814335/a1d23936-7e25-11e5-8ea2-0a730cf76f21.png)
