### PR TITLE
Improve inventory documentation

### DIFF
--- a/inventory/management/lots_serial_numbers/serial_numbers.rst
+++ b/inventory/management/lots_serial_numbers/serial_numbers.rst
@@ -50,6 +50,7 @@ Transfers
 
 In order to process a transfer of a product tracked by serial number,
 you have to input the number(s).
+In order to be able to assign serial numbers to products you will first need to mark your transfer as to do. Click on the **MARK AS TODO** button and you will see the serial number icon show up.
 
 Click on the serial number icon :
 


### PR DESCRIPTION
Without adding the information about marking a transfer as TO DO you will not see the icon show up and this is really confusing.