### PR TITLE
Corrected udev rule name

### DIFF
--- a/point_of_sale/overview/setup.rst
+++ b/point_of_sale/overview/setup.rst
@@ -260,7 +260,7 @@ Then we add the user who will run the OpenERP server to ``usbusers``
 
 Then we need to create a udev rule that will automatically allow members
 of ``usbusers`` to access raw USB devices. To do so create a file called
-``99-usbusers.rule`` in the ``/etc/udev/rules.d/`` directory with the
+``99-usbusers.rules`` in the ``/etc/udev/rules.d/`` directory with the
 following content::
 
     SUBSYSTEM=="usb", GROUP="usbusers", MODE="0660"


### PR DESCRIPTION
The udev rule must be 99-usbusers.rules instead of 99-usbusers.rule because otherwise it would not work