### PR TITLE
Removed "Specific Identification" From Title

### DIFF
--- a/inventory/routes/strategies/removal.rst
+++ b/inventory/routes/strategies/removal.rst
@@ -1,5 +1,5 @@
 ========================================================================
-What is a removal strategy (FIFO, LIFO, FEFO, Specific Indentification)?
+What is a removal strategy (FIFO, LIFO, and FEFO)?
 ========================================================================
 
 Overview


### PR DESCRIPTION
Specific Identification is mentioned in the title, but never in the body text of this document. It should be removed from the title until the corresponding body text is written.