### PR TITLE
fix in the negative reminder delay example

### DIFF
--- a/accounting/receivables/getting_paid/automated_followups.rst
+++ b/accounting/receivables/getting_paid/automated_followups.rst
@@ -68,7 +68,7 @@ Odoo defines several actions for every reminder:
 .. Note:: 
     As you need to provide a number of days relative to the due date,
     you can use a negative number. As an example, if an invoice is issued
-    the January 1st but the due date is January 30, if you set a reminder 3
+    the January 1st but the due date is January 20, if you set a reminder 3
     days before the due date, the customer may receive an email in January
     17.
 


### PR DESCRIPTION
If we have -3 as reminder delay and the reminder occures on the 17th, the correct due date is 20 and not 30