### PR TITLE
Fix error with order used instead of invoice

### DIFF
--- a/sales/overview/main_concepts/invoicing.rst
+++ b/sales/overview/main_concepts/invoicing.rst
@@ -66,7 +66,7 @@ defined on the contract.
 :menuselection:`eCommerce Order --> Invoice`
 --------------------------------------------
 
-An eCommerce order will also trigger the creation of the order when it
+An eCommerce order will also trigger the creation of the invoice when it
 is fully paid. If you allow paying orders by check or wire transfer,
 Odoo only creates an order and the invoice will be triggered once the
 payment is received.


### PR DESCRIPTION
In chapter `eCommerce Order --> Invoice` : the sentence  «An eCommerce order will also trigger the creation of the order when it is fully paid.»  means obviously 
«An eCommerce order will also trigger the creation of the invoice when it is fully paid.»

Same error in 11 version