### PR TITLE
Improve Credit Card Documentation

### DIFF
--- a/accounting/receivables/customer_payments/credit_cards.rst
+++ b/accounting/receivables/customer_payments/credit_cards.rst
@@ -47,6 +47,7 @@ Create a Journal called 'Credit card payments' with the following data:
 -  **Default debit account**: Credit cards
 -  **Default credit account**: Credit cards
 
+Be careful that the account type should not be "Bank and Cash". 
 Once it's done, don't forget to set the "Credit cards" account as "Allow
 Reconciliation".
 


### PR DESCRIPTION
Add additional information on the documentation (if the account type is "Bank and Cash", the reconciliation doesn't work).