### PR TITLE
Clarify tax-included configuration

### DIFF
--- a/accounting/others/taxes/tax_included.rst
+++ b/accounting/others/taxes/tax_included.rst
@@ -3,8 +3,8 @@ How to set tax-included prices
 ==============================
 
 In most countries, B2C prices are tax-included. To do that in Odoo, check
-*Included in Price* for your sales taxes in
-:menuselection:`Accounting --> Configuration --> Taxes`.
+*Included in Price* for each of your sales taxes in
+:menuselection:`Accounting --> Configuration --> Accounting --> Taxes`.
 
 .. image:: media/tax_included.png
    :align: center


### PR DESCRIPTION
Make it clear that tax-included it is not a gobal option
Fix wrong path

(also for 11.0)