### PR TITLE
[IMP] unsplash: new guidelines negociated with Unsplash

### DIFF
--- a/general/unsplash/unsplash_access_key.rst
+++ b/general/unsplash/unsplash_access_key.rst
@@ -2,6 +2,12 @@
 How to generate an Unsplash access key
 =======================================================
 
+.. tip::
+  **As a SaaS user**, Unsplash is ready to use. You won't need to follow this guide to set up Unsplash informations as you will use our own Odoo Unsplash key in a transparent way.
+
+Generate an Unsplash access key for **non-Saas** users
+======================================================
+
 - Create an account on `Unsplash.com <https://unsplash.com/join>`_.
 
 - Go to your `applications dashboard <https://unsplash.com/oauth/applications>`_ and click on **New Application**.
@@ -14,7 +20,7 @@ How to generate an Unsplash access key
 .. image:: media/accept_terms.png
     :align: center
 
-- You will be prompted to insert an **Application name** and a **Description**. Once done, click on **Create application**.
+- You will be prompted to insert an **Application name** and a **Description**. Please prefix your application name by "**Odoo: **" so it can be recognized as an Odoo instance by Unsplash. Once done, click on **Create application**.
 
 .. image:: media/app_infos.png
     :align: center
@@ -24,3 +30,5 @@ How to generate an Unsplash access key
 .. image:: media/access_key.png
     :align: center
 
+.. warning::
+  **As a non-SaaS user**, you won't be able to register for a production Unsplash key and will be limited to your test key that has a 50 Unsplash requests per hour restriction.

--- a/general/unsplash/unsplash_application_id.rst
+++ b/general/unsplash/unsplash_application_id.rst
@@ -2,7 +2,8 @@
 How to generate an Unsplash application ID
 =======================================================
 
-- You should first create and set up your Unsplash application with this tutorial: `How to generate an Unsplash access key <https://www.odoo.com/documentation/user/unsplash_access_key.html>`_.
+.. tip::
+  You should first create and set up your Unsplash application with this tutorial: `How to generate an Unsplash access key <https://www.odoo.com/documentation/user/unsplash_access_key.html>`_.
 
 - Go to your `applications dashboard <https://unsplash.com/oauth/applications>`_ and click on your newly created Unsplash application under **Your applications**.
 


### PR DESCRIPTION
Unsplash CEO asked us to stop exposing our key client side (even if it was
only in the browser network and allowed by Unsplash API team leader).

Also, all our Odoo instance, on premise or not should share the same
production key, which is not possible for us obviously.

After multiple exchange, it has been negociated that:
1. Our non saas user won't be able to apply for a production key and should
   prefix they Unsplash application name by 'Odoo:'. Their key will remain in
   test mode.
   Indeed, Unsplash won't be able to review every Odoo application and ensure
   it respects the API terms and it is a real application.
2. Our saas user will query Unsplash server side so the key remain hidden.
3. The documentation should explain it all