### PR TITLE
[FIX] Inventory: remove wrong pdf

### DIFF
--- a/inventory/barcode/setup/software.rst
+++ b/inventory/barcode/setup/software.rst
@@ -13,12 +13,6 @@ with the barcode scanner.
       :target: ../../../_static/files/barcodes_actions.pdf
 
 
-.. note::
-    Print this document to be able to use your barcode scanner to perform more actions.
-    
-    Document: |download_barcode|
-
-
 Set products barcodes
 =====================
 

--- a/inventory/barcode/setup/software.rst
+++ b/inventory/barcode/setup/software.rst
@@ -8,11 +8,6 @@ attributing barcodes to products, pickings locations, etc. allows you to
 work more efficiently by controlling the software almost exclusively
 with the barcode scanner.
 
-.. |download_barcode| image:: ../../../_static/banners/pdf-icon.png
-      :alt: Download Barcode Document
-      :target: ../../../_static/files/barcodes_actions.pdf
-
-
 Set products barcodes
 =====================
 


### PR DESCRIPTION
The pdf with the barcode actions is not up-to-date, it's removed here. Now it's easily accessible from the inventory settings so it's not necessary to have in the documentation anymore (and it's easier to avoid any issue across versions).