### PR TITLE
[FIX] base: Correct state in res_partner template

### DIFF
--- a/_static/example_files/o2m_customers_contacts.csv
+++ b/_static/example_files/o2m_customers_contacts.csv
@@ -1,9 +1,9 @@
 Name,Is a company,Related company,Address type,Customer,Supplier,Street,ZIP,City,State,Country
-Aurora Shelves,1,,,1,0,25 Pacific Road,95101,San José,CA,United States
-Roger Martins,0,Aurora Shelves,Invoice address,1,0,27 Pacific Road,95102,San José,CA,United States
-House Sales Direct,1,,,1,0,104 Saint Mary Avenue,94059,Redwood,CA,United States
-Yvan Holiday,0,House Sales Direct,Contact,1,0,104 Saint Mary Avenue,94060,Redwood,CA,United States
-Jack Unsworth,0,House Sales Direct,Invoice address,1,0,227 Jackson Road,94061,Redwood,CA,United States
-Michael Mason,0,,,1,0,16 5th Avenue,94104,San Francisco,CA,United States
-International Wood,1,,,1,0,748 White House Boulevard,20004,Washington,DC,United States
-Sharon Pecker,0,International Wood,Invoice address,1,0,755 White House Boulevard,20005,Washington,DC,United States
+Aurora Shelves,1,,,1,0,25 Pacific Road,95101,San José,California,United States
+Roger Martins,0,Aurora Shelves,Invoice address,1,0,27 Pacific Road,95102,San José,California,United States
+House Sales Direct,1,,,1,0,104 Saint Mary Avenue,94059,Redwood,California,United States
+Yvan Holiday,0,House Sales Direct,Contact,1,0,104 Saint Mary Avenue,94060,Redwood,California,United States
+Jack Unsworth,0,House Sales Direct,Invoice address,1,0,227 Jackson Road,94061,Redwood,California,United States
+Michael Mason,0,,,1,0,16 5th Avenue,94104,San Francisco,California,United States
+International Wood,1,,,1,0,748 White House Boulevard,20004,Washington,D.C.,United States
+Sharon Pecker,0,International Wood,Invoice address,1,0,755 White House Boulevard,20005,Washington,D.C.,United States


### PR DESCRIPTION
State from the template was 'CA' for California - not recognized on import
Changed it to 'California' to match with the db state

Already changed on the V12 template of the Contact app

opw 1943904