### PR TITLE
[FIX] accounting: Fix mexican view due to a mistake with special characters

### DIFF
--- a/accounting/localizations/mexico.rst
+++ b/accounting/localizations/mexico.rst
@@ -271,34 +271,34 @@ process in Odoo, this considerations to understand the behavior are important.
 
    **1.1. How can I generate an invoice with payment term `PUE`?**
 
-   `According to the SAT documentation`_ a payment is classified as `PUE` if
+   `According to the SAT documentation`_ a payment is classified as ``PUE`` if
    the invoice was agreed to be fully payed before the 17th of the next
    calendar month (the next month of the CFDI date), any other condition
-   will generate a `PPD` invoice.
+   will generate a ``PPD`` invoice.
 
    **1.2. How can I get this with Odoo?**
 
    In order to set the appropriate CFDI payment term (PPD or PUE), you can
-   easily set it by using the `Payment Terms` defined in the invoice.
+   easily set it by using the ``Payment Terms`` defined in the invoice.
 
-   - If an invoice is generated without `Payment Term` the attribute
-     `MetodoPago` will be `PUE`.
+   - If an invoice is generated without ``Payment Term`` the attribute
+     ``MetodoPago`` will be ``PUE``.
 
    - Today, if is the first day of the month and is generated an invoice with
-     `Payment Term` `30 Net Days` the `Due Date` calculated is going to be
-     the first day of the following month, this means its before the 17th of
-     the next month, then the attribute `MetodoPago` will be `PUE`.
+     ``Payment Term`` ``30 Net Days`` the ``Due Date`` calculated is going to
+     be the first day of the following month, this means its before the 17th
+     of the next month, then the attribute ``MetodoPago`` will be ``PUE``.
 
-   - Today, if an invoice is generated with `Payment Term` `30 Net Days` and
-     the `Due Date` is higher than the day 17 of the next month the
-     `MetodoPago` will be `PPD`.
+   - Today, if an invoice is generated with ``Payment Term`` ``30 Net Days``
+     and the ``Due Date`` is higher than the day 17 of the next month the
+     ``MetodoPago`` will be ``PPD``.
 
-   - If having a `Payment Term` with 2 lines or more, for example
-     `30% Advance End of Following Month`, this is an installments term,
-     then the attribute `MetodoPago` will be `PPD`.
+   - If having a ``Payment Term`` with 2 lines or more, for example
+     ``30% Advance End of Following Month``, this is an installments term,
+     then the attribute ``MetodoPago`` will be ``PPD``.
 
 2. To test a normal signed payment just create an invoice with payment term
-   `30% Advance End of Following Month` and then register a payment to it.
+   ``30% Advance End of Following Month`` and then register a payment to it.
 3. You must print the payment in order to retrieve the PDF properly.
 4. Regarding the "Payments in Advance" you must create a proper invoice with
    the payment in advance itself as a product line setting the proper SAT code


### PR DESCRIPTION
In the mexican documentation we have an errror like the one shown bellow: 
![Mexico: Documentation Error](https://user-images.githubusercontent.com/26889951/55254132-b4f49300-521c-11e9-8e90-9f9a78bcb869.png)
([UNKNOWN NODE title_reference])

In order to make those errors disappear and that the correct information is displayed, what this PR do, is change some special characters.