### PR TITLE
Wrong information regarding open ports in outgoing email servers

### DIFF
--- a/odoo_sh/getting_started/create.rst
+++ b/odoo_sh/getting_started/create.rst
@@ -157,7 +157,7 @@ all outgoing email servers are disabled so you use the Odoo.sh email server prov
 
 .. Warning::
 
-  Ports 25, 465 and 587 are blocked. If you want to use your own email servers, they must be configured on other ports.
+  Port 25 is (and will stay) closed. If you want to connect to an external SMTP server, you should use ports 465 and 587.
 
 Check your scheduled actions
 ----------------------------


### PR DESCRIPTION
On page https://www.odoo.sh/faq#internet_access we mentions that ports 465 and 587 are open.

We need to align the getting_started page as well.