### PR TITLE
[FIX]  accounts unbalanced in continental accounting for stock transa…

### DIFF
--- a/_static/coa-valuation-continental.js
+++ b/_static/coa-valuation-continental.js
@@ -225,7 +225,7 @@
     }, {
         label: "Vendor Invoice (PO €48, Invoice €50)",
         operations: [
-            {account: EXPENSES.PURCHASED_GOODS.code, debit: constant(48)},
+            {account: EXPENSES.PURCHASED_GOODS.code, debit: constant(50)},
             {account: ASSETS.TAXES_PAID.code, debit: constant(50 * 0.09)},
             {account: LIABILITIES.ACCOUNTS_PAYABLE.code, credit: constant(50 * 1.09)},
         ]


### PR DESCRIPTION
…ctions

In the documentation of continental accounting for stock transactions.
In the perpetual inventory valuation, when we choose the option 'Vendor
Invoice (PO €48, Invoice €50)', the purchase goods must be €50 and not
€48 as is the case for the moment.

opw-2052725