### PR TITLE
[FIX] Remove screenshot with non-visible field

### DIFF
--- a/inventory/shipping/operation/invoicing.rst
+++ b/inventory/shipping/operation/invoicing.rst
@@ -61,11 +61,8 @@ On your sale order, choose the carrier that will be used. Click on
 The price is computed when you **save** the sale order. Confirm the sale
 order and proceed to deliver the product.
 
-The real shipping cost are computed when the delivery order is
-validated.
-
-.. image:: media/invoicing02.png
-   :align: center
+The real shipping cost is computed when the delivery order is
+validated, you can see the real cost in the chatter of the delivery order.
 
 Go back to the sale order, the real cost is now added to the sale
 order.


### PR DESCRIPTION
The field carrier_price is no longer viewable in the delivery order by default and the screenshot could bring confusion to people that are following the documentation.