### PR TITLE
[IMP] support: display images instead of unicode

### DIFF
--- a/_extensions/odoo/translator.py
+++ b/_extensions/odoo/translator.py
@@ -377,7 +377,11 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
                     "Unsupported alignment value \"%s\"" % node['align'],
                     location=doc
                 )
-        # todo: explicit width/height/scale?
+        attrs['style'] = '; '.join(
+            '%s:%s' % (name, node[name] + ('px' if re.match(r'^[0-9]+$', node[name]) else ''))
+            for name in ['width', 'height']
+            if name in node
+        )
         self.body.append(self.starttag(node, 'img', **attrs))
     def depart_image(self, node): pass
     def visit_figure(self, node):

--- a/support/supported_versions.rst
+++ b/support/supported_versions.rst
@@ -20,47 +20,56 @@ This matrix shows the support status of every version.
 
 **Major releases are in bold type.**
 
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-|                    | Odoo Online | Odoo.sh | On-Premise   |   Release date |                                              |
-+====================+=============+=========+==============+================+==============================================+
-| **Odoo 13.0**      | 🟢          | 🟢      | 🟢           | October 2019   |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 12.saas~3     | 🟢          | N/A     | N/A          | August 2019    |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| **Odoo 12.0**      | 🟢          | 🟢      | 🟢           | October 2018   |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 11.saas~3     | 🟢          | N/A     | N/A          | April 2018     |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| **Odoo 11.0**      | 🟢          | 🟢      | 🟢           | October 2017   | *End-of-support is planned for October 2020* |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 10.saas~15    | 🟠          | N/A     | N/A          | March 2017     |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 10.saas~14    | 🟠          | N/A     | N/A          | January 2017   |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| **Odoo 10.0**      | 🟠          | 🟠      | 🔴           | October 2016   |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 9.saas~11     | 🟠          | N/A     | N/A          | May 2016       |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| **Odoo 9.0**       | 🟠          | N/A     | 🔴           | October 2015   |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| Odoo 8.saas~6      | 🟠          | N/A     | N/A          | February 2015  |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
-| **Odoo 8.0**       | 🟠          | N/A     | 🔴           | September 2014 |                                              |
-+--------------------+-------------+---------+--------------+----------------+----------------------------------------------+
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+|                    | Odoo Online | Odoo.sh  | On-Premise   |   Release date |                                              |
++====================+=============+==========+==============+================+==============================================+
+| **Odoo 13.0**      |    |green|  | |green|  |   |green|    | October 2019   |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 12.saas~3     |    |green|  | N/A      | N/A          | August 2019    |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| **Odoo 12.0**      |    |green|  | |green|  |   |green|    | October 2018   |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 11.saas~3     |    |green|  | N/A      | N/A          | April 2018     |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| **Odoo 11.0**      |    |green|  | |green|  |   |green|    | October 2017   | *End-of-support is planned for October 2020* |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 10.saas~15    |   |orange|  | N/A      | N/A          | March 2017     |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 10.saas~14    |   |orange|  | N/A      | N/A          | January 2017   |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| **Odoo 10.0**      |   |orange|  | |orange| |    |red|     | October 2016   |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 9.saas~11     |   |orange|  | N/A      | N/A          | May 2016       |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| **Odoo 9.0**       |   |orange|  | N/A      |    |red|     | October 2015   |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| Odoo 8.saas~6      |   |orange|  | N/A      | N/A          | February 2015  |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
+| **Odoo 8.0**       |   |orange|  | N/A      |    |red|     | September 2014 |                                              |
++--------------------+-------------+----------+--------------+----------------+----------------------------------------------+
 
 
 .. note::
 
-    🟢 Supported version
+    |green| Supported version
 
-    🔴 End-of-support
+    |red| End-of-support
 
     N/A Never released for this platform
 
-    🟠 Some of our older customers may still run this version on our Odoo Online servers, we provide help only on blocking issues and advise you to upgrade.
+    |orange| Some of our older customers may still run this version on our Odoo Online servers, we provide help only on blocking issues and advise you to upgrade.
 
     🏁 Future version, not released yet
 
+
+.. |green| image:: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDphNmMxNWY4YS00NjY3LTQ3MWEtOTJhMy05ZDdmN2NkM2M5YmEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDFGNDhDMjZGODREMTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDFGNDhDMjVGODREMTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpjM2E2MzlhMC00YzgzLTRlYjgtYTY5Zi1kMWQ2ODM0ODUxNGQiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6YTZjMTVmOGEtNDY2Ny00NzFhLTkyYTMtOWQ3ZjdjZDNjOWJhIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+AIIG+AAAAqxJREFUeNq8lz9oFEEUxnfXFUQsDBIhnVhqYUSwMYVgo8QEO5GIIop/CkGCaGOpaIiVJJCIaQJaBCsPEaLYCVpYqU0qFURMoYly2MzM+nt7s3fD7O4lMbspvntv3gzzvffd7PwJp8xUkCRJYIxpWx9a603Yw2AQ/xB2N7YHhGCZ9hfsO/ACvAJNECitAqNNoJSSOdqQdixkGQpIt4Az4Dw4YBNoT2DH9Ngk+sEl8AnMgkeQ/vRJM0RFFVocAW8ZNI096JNqowsnpMq92DHwHv9U0ZiUuKTSm2CeAfsyMp9UJCyb1Mq5Syv9BP+BJO3KXFbxOLhHZ/Q/pAX/6VUqf4yN3bhPfANcd8lWQyqLqMh3kjlJfNId4xLLqr27VlJ/tSJvWfwi/jm/Ylm9kxXK267ci48T75PkMuLTBPdULG9uDNiBP5pWzM9mcKUmeXPJEDuL3xtDNAD6q5K3m+wWvWBQiIfd/3YlebP4auUtSfxYzM/Aeiv1N4ecvPmx+2O74dcrr/K2WaP7pOLtGyRvi7jFs1WIw/STqlNe06nW9oXyOf3u9rmsYXPoxLX9lFRpQn8je4hXsTkEKxXgKLAY2ZtDNZtDd3k7lwdtPghxY4PkdQ+feSF+DRbqltch/YN9FtmL2Uzd8jr2KfZrZDsfMvBbzfKmq9neboLITrKEHa1R3szeRpEFkxjO42whKT1H50RN8op9DsayzSryZLxGRXMVyyv2DcmNAC3j0oo9qaRjhMmnK5S3waTHsctptZAmJskRS6Xw6Mv4F8DiOuRtYm+BE2Apu1QKqdioy4Y/QwbybLlP/HtbXkfmEtJf6fNFXh9G3xEJU3kdUkE41BhqZa8K9upObKfcGsBROcTlPGWybfbR1qT9g/ZHJnxJWxbR5/T4swvJfxCK/0+AAQAmKbWesdxiOAAAAABJRU5ErkJggg==
+   :width: 15
+
+.. |red| image:: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDphNmMxNWY4YS00NjY3LTQ3MWEtOTJhMy05ZDdmN2NkM2M5YmEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDFGNDhDMkFGODREMTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDFGNDhDMjlGODREMTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpjM2E2MzlhMC00YzgzLTRlYjgtYTY5Zi1kMWQ2ODM0ODUxNGQiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6YTZjMTVmOGEtNDY2Ny00NzFhLTkyYTMtOWQ3ZjdjZDNjOWJhIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+8nyGFAAAAoxJREFUeNq8lz9oFEEUh/fGFUQsDBIhqcRSCyMHNloEbJRIsBOJKKL4pxBERBtLxYRYiSkU0wS0ECuPIESxE7SwUptUKoiYQqMSbHZm/N7uzN7csnceunvFd+/N3O7+9v12dmemYZrNyFobmSjKosvDqK1dRxynPUG+l3w7cQga8IP2R+JreArPYU1n56UkQe7bsYhZLypCnaIb4Dicot10N5BfwGQMuZsYg7PwHhbgPnwrinpUsbog3w+vOOgu7T1lorqcnTADb+Co7iZsy0WvwhIH7JJ2UaiHaGjnNnhIfltuumi7Mm3LvOgsTPOnMiVCfYqG7QvwAOKkh9VX4LJ2bd0eXH2LduEIzOVtY1zFmcA43MxF/7HSpHv/GfKTxYpl9M5VaG+3/lmqHUmCZ3yMzh0V29sJ9sIW8ktpxfysh/M12dvZjwZ9J8iHYy6+D9GxGu3Nqm23h2EiRnQyfLaV21v+38FYS8V1VersLcl3x+6DX6u9SeH6xBGpePOA7M2/kOQbRbhRt725oHtdoSGv08/K7SXmr1O5A7+Vm8Sr+Dj0fTyaK8qtHCr5OPzF3nCAvRXh1oDsDUf1kgi/gOUB2OvjL+IT5RZm8wOw18fHfC0/KXfiPfhcs73paEZ02s9O0rHqp6ua7I3cAuM6+bL1wu6uH5HfqcleEV0kn/FtVbjwRZ3dQJX2iuhL8inQ2q3jVeEk+WNK1tIV2tsiP2SyHUcqaoJnHNqbwDny07DyH/auIXqN/DCsFrdGqsfonadS2bbcSoz54u1NnNU9Kv0u2xfZfZDfAKNL9mON1uhomiQlzzPo2yqrBjggk7jMp8RNMsuklVn7lfiO+Iy4yMU/mE67o3DHInb/EWAA56Ap3OqLYGgAAAAASUVORK5CYII=
+   :width: 15
+
+.. |orange| image:: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA3hpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDphNmMxNWY4YS00NjY3LTQ3MWEtOTJhMy05ZDdmN2NkM2M5YmEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NTA0MTQ2QzdGODQ5MTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NTA0MTQ2QzZGODQ5MTFFOUFCRkRBRDVFRERCQzYwOEEiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpjM2E2MzlhMC00YzgzLTRlYjgtYTY5Zi1kMWQ2ODM0ODUxNGQiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6YTZjMTVmOGEtNDY2Ny00NzFhLTkyYTMtOWQ3ZjdjZDNjOWJhIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+AQXwQQAAAtZJREFUeNq8lz1oFEEUx/cmKwSxMEiEdGKphZGAjSkCNoaI2IlEFFH8KAQJoo2digmxkqSImEaIRbAyiBDFTtDCythYqSCihSZKuObmjb/Zmf26ryzcruFe3nv7dua389+5mbmaXrsdtP8zfDARnOkLjIwRT2CHifcakQHiWiB6A/+F/F2g9QvyV+SbRnRATnsdmMhLlBtpRD7sCjXSD/QM/jwNRzD7AHzEdSRRhwPuIfQwdon8I9DHdP6I/JcRndzrHsbFqgv0iBHzFr9Aw0OtUGcmfgA/KjrfTzzDtffEp2JQVI/ucSNWHaA3ga7iDySQlpFql+scNJVX9B6gT4gfIHWf8ded3DlwAp0FOo1XnaGSQqUtNJEU4FVGuYSFgW4k96km6A2g1y2oPbRJ3i2giRpan8Tms/epDHQM6L3O0ELyZkcaNMl7EX8urikHNf1A50uU102iaCI1srVZakNOatfhaf7tK1neZCLFsxnoLuKpSGq+p9uoXqlI3qZFJLKzxIMh1VE6Gy5P3ixU8lD3YIPEEyGdHcdUKfJ2G2l83bUbt+DRnkdaFKpdO+KDoV/wq5VXWubHUAhkZ+XyxtB0gm0P/dZWrbxZqLte43us/5S0OBSF2vvrym/iZSwOxaCO9VNFJwcpaXEoAnW1D4pgpQi0Z3lTqM1X7Tt+TfLpP8gbQ//inyl/MFusXF4tcf6U+lflGz0k+VaxvNbXqU/bXPkRrFOYqlDeOL8TvVZjwam8y8RzFclr68/xM8afcJTROQmvMarlkuW19Tf4SWMv+KVZBZKTV2OT2EKJ8q7gjwHdyB42lN+cs500aHQZf8GuMD3Iu0n9Fv4E0PUsNBCD1P5kn5c36nSRzkeI72Pfk41Bbynvb7z9+WJ/fdw1dj1ugtr3XKsvTXSeSGm8Gz8O9KjdxO1+Sr7D7jJcsyP7Qcdr5C/xTCL92f3Yyx+VY6g92f4TYABoYgaZy0z5agAAAABJRU5ErkJggg==
+   :width: 15
 
 I run an older version of Odoo/OpenERP/TinyERP
 ==============================================


### PR DESCRIPTION
While red is supported by most OS as in the unicode version 6 (~2010)
https://dict.emojiall.com/en/emoji/%F0%9F%94%B4
    
the green and orange circles are very recent so only modern system (by
the way I use Arch) can render it
https://dict.emojiall.com/en/emoji/%F0%9F%9F%A2

Add a patch to be able to use `width` attribute on images