### PR TITLE
Inventory replenishment doesn't change the uom

### DIFF
--- a/inventory/management/products/uom.rst
+++ b/inventory/management/products/uom.rst
@@ -82,7 +82,7 @@ Replenishment
 -------------
 
 When doing a replenishment via the *Replenish* button on the product
-form, you have the possibility to change the unit of measure.
+form, you have the possibility to use a different unit of measure.
 
 .. image:: media/uom_07.png
     :align: center


### PR DESCRIPTION
The statement:
    "When doing a replenishment via the Replenish button on the product form, you have the possibility to change the unit of measure."
Implies that when a replenishment is done the purchase uom will be changed when actually it just creates a stock.move with a calculated amount based on the product's uom.