### PR TITLE
[IMP] documentation: make the multiversion, multilang work

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -360,8 +360,11 @@ def versionize(app, pagename, templatename, context, doctree):
     if not (app.config.canonical_root and app.config.versions):
         return
 
+    # remove last fragment containing the version
+    root = '/'.join(app.config.canonical_root.rstrip('/').split('/')[:-1])
+
     context['versions'] = [
-        (vs, _build_url(app.config.canonical_root, vs, pagename))
+        (vs, _build_url(root, vs, pagename))
         for vs in app.config.versions.split(',')
         if vs != app.config.version
     ]
@@ -414,16 +417,24 @@ def canonicalize(app, pagename, templatename, context, doctree):
     """ Adds a 'canonical' URL for the current document in the rendering
     context. Requires the ``canonical_root`` setting being set. The canonical
     branch is ``master`` but can be overridden using ``canonical_branch``.
+    /documentation/user/12.0/sale.html -> /documentation/user/13.0/sale.html
+    /documentation/user/11.0/fr/website.html -> /documentation/user/13.0/fr/website.html
     """
     if not app.config.canonical_root:
         return
 
+    # remove last fragment containing the version
+    root = '/'.join(app.config.canonical_root.rstrip('/').split('/')[:-1])
+    root += '/' + app.config.canonical_branch
+    current_lang = app.config.language or 'en'
+
     context['canonical'] = _build_url(
-        app.config.canonical_root, app.config.canonical_branch, pagename)
+        root, (current_lang != 'en' and current_lang or ''), pagename)
 
 def _build_url(root, branch, pagename):
-    if not branch:
-        root = root.rstrip('/')
+    root = root.rstrip('/')
+    if branch:
+        root += '/'
     return "{canonical_url}{canonical_branch}/{canonical_page}".format(
         canonical_url=root,
         canonical_branch=branch,


### PR DESCRIPTION
Keep the language in multilang versions of pages. The canonical should look like:
- /documentation/user/12.0/sale.html -> /documentation/user/13.0/sale.html
- /documentation/user/11.0/fr/website.html -> /documentation/user/13.0/fr/website.html

Needs the changes at odoo/saas-automation#40 that will change the `canonical_root` from `https://www.odoo.com/documentation/user/` to `https://www.odoo.com/documentation/user/12.0/`
This way, the language switcher will keep the current version, changing from English to French on `/documentation/user/12.0/website.html` will lead to `/documentation/user/12.0/fr/website.html`, not `/documentation/user/13.0/website.html` as before