### PR TITLE
[REM] Removal of mention of Storno accounting

### DIFF
--- a/accounting/overview/main_concepts/in_odoo.rst
+++ b/accounting/overview/main_concepts/in_odoo.rst
@@ -65,8 +65,6 @@ In particular, Odoo's core accounting engine supports:
   sold/delivered.
 * European accounting where expenses are accounted at the supplier
   bill.
-* Storno accounting (Italy) where refund invoices have negative
-  credit/debit instead of a reverting the original journal items.
 
 Odoo also have modules to comply with IFRS rules.
 


### PR DESCRIPTION
There was a mention that Odoo supports Storno accounting since v9.0.
It is not true and this change must be forward ported on all branches.

Thanks