### PR TITLE
[IMP] sale_amazon: add information about compliance with Amazon's sec…

### DIFF
--- a/sales/sale_amazon.rst
+++ b/sales/sale_amazon.rst
@@ -1,9 +1,10 @@
-====================
-Amazon MWS Connector
-====================
+================
+Amazon Connector
+================
 
 .. toctree::
    :titlesonly:
 
+   sale_amazon/apply
    sale_amazon/setup
    sale_amazon/manage

--- a/sales/sale_amazon/apply.rst
+++ b/sales/sale_amazon/apply.rst
@@ -1,0 +1,146 @@
+================================
+Apply for Amazon MWS Access Keys
+================================
+
+.. _amazon/developer-form:
+
+Submit the Amazon MWS Developer Registration and Assessment Form
+================================================================
+
+In order to synchronize your Amazon orders with Odoo, Amazon MWS access keys are required.
+They can be obtained by submitting the **Amazon MWS Developer Registration and Assessment form** to
+register as a developer. Once recognized by Amazon as a developer (i.e. you make use of an
+application connecting to MWS), you will be granted Amazon MWS access keys.
+
+First, visit the `Amazon Marketplace Web Service documentation
+<http://docs.developer.amazonservices.com/en_US/dev_guide/DG_Registering.html>`_ and follow the
+instructions to register as a developer. Take care to choose the form "I represent a seller
+organization integrating with Amazon MWS for its own selling account only.".
+
+Fill out the *Developer Registration and Assessment form* as suggested below and provide your own
+contact information in the **Developer contact information** section. In the **Business use
+information** section, select the correct region of your seller account. For the other sections,
+adapt your responses in accordance with your business case.
+
+Give a particular attention to **Merchant Fulfilled Shipping**. It should only be checked if you
+ship your products yourself. You should uncheck it if you sell exclusively with the *Fulfillment by
+Amazon* service. Please note that requesting this function is not recommended if you are hosted on
+*Odoo Online* or *Odoo.sh* as the additional security requirements asked by Amazon may not be met by
+Odoo.
+
+.. warning::
+   Depending on several factors (your region, whether you checked the **Merchant Fulfilled
+   Shipping** function (i.e. you request access to Personally Identifiable Information of your
+   customers), etc.), Amazon may request you to fill out a second form before granting you MWS
+   access keys. As that form depends on the data protection policy of the region of your seller
+   account (e.g. GDPR in Europe), we cannot provide you with a pre-filled form. Instead, the answers
+   of questions related to Odoo are listed in the `Answer the Additional Form`_ section.
+
+.. tip::
+   If you need assistance for your application for Amazon MWS access keys, `submit a support ticket
+   to Odoo <https://www.odoo.com/help>`_.
+
+.. image:: ./media/dev_form.png
+
+Answer the Additional Form
+==========================
+
+This section lists all questions asked by Amazon in additional forms. The answers are tailored for
+*Odoo Online* and *Odoo.sh*. If you did not receive any additional form after your :ref:`initial
+application for Amazon MWS keys <amazon/developer-form>`, you may disregard this section.
+
+.. warning::
+   If you are not hosted on Odoo.com (*online*) or on Odoo.sh, you should adapt the answers related
+   to hosting according to your own infrastructure and data protection policy.
+
+- **Describe all functionalities in your application where Personally Identifiable Information (e.g.
+  customer name, street address, billing address) is required.**
+
+  ► If you did not apply for the *Merchant Fulfilled Shipping* function:
+    | - Generation of customer invoices
+
+  ► If you applied for the *Merchant Fulfilled Shipping* function:
+    | - Generation of delivery orders
+    | - Generation of customer invoices
+
+- **List all outside parties with whom your organization shares Amazon Information (e.g. information
+  exposed by Amazon through Amazon MWS, Seller Central, or Amazon's public-facing websites) and
+  describe how your organization shares this information.**
+
+  ► If you do not share Amazon Information with outside parties:
+    Odoo does not share any information with outside parties.
+
+  ► If you share Amazon Information with outside parties:
+    [Description of your organization's policy regarding Amazon Information]
+
+- **List all non-Amazon MWS sources where you retrieve Amazon Information.**
+
+  Odoo only relies on MWS to retrieve Amazon Information.
+
+- **Describe how your organization restricts public access to databases, file servers, and
+  desktop/developer endpoints.**
+
+  | - Access to the postgreSQL database through the network is disabled and standard ports are
+  |   closed. The database is only accessible through a socket on the server itself.
+  | - The reverse proxy only serves whitelisted directories that are only from sources controlled by
+  |   Odoo S.A.
+  | - API endpoints are password protected (PBKDF2 & SHA512 encryption, salted, and stretched for
+  |   thousands of rounds).
+  | - Login credentials are always transmitted securely over HTTPS.
+  |
+
+- **Describe how your organization uniquely identifies employees and restricts access to Amazon
+  Information on a need-to-know basis.**
+
+  ► If all your employees are properly assigned separate users and given only relevant access rights:
+    Access rights are provided to employees based on their role within the company and are
+    progressive, based on their responsibility.
+
+    For instance, salespersons only have access to their own leads/quotes (and thus no access to
+    quotes generated through the Amazon API). A salesmanager has access to all quotes/leads for
+    reporting purposes (including quotes generated through the Amazon API). A quote will generate a
+    delivery order which will be accessible to a 'normal' user of the Inventory application for him
+    to be able to print the delivery label and pack the products.
+
+  ► If your employees share users or if they are given more rights than needed:
+    [Description of your organization's policy for the assignation of users and access rights to
+    your employees]
+
+- **Describe how your organization prevents Amazon Information from being accessed from employee
+  personal devices.**
+
+  Odoo does not prevent employees from accessing the organization's data from personal devices.
+  Role-based restrictions and access rights still apply.
+
+- **Provide details on your organization's privacy and data handling policies (a link to your policy
+  is also acceptable).**
+
+  [Description of your organization's privacy and data handling policies]
+
+- **Describe where your organization stores Amazon Information and provide details on how you
+  encrypt this information (e.g., algorithm).**
+
+  Amazon Information is stored in an unencrypted database. Direct access to the database is not
+  possible for the customer outside of UI interactions or API calls. Granular access rights control
+  ensures that access is not shared to all users of the database.
+
+- **Describe how your organization backups or archives Amazon Information and provide details on how
+  you encrypt this information (e.g., algorithm).**
+
+  The entire database is backed up once a day and backups are kept for a minimum of three months
+  according to the `Odoo Online SLA <https://www.odoo.com/cloud-sla>`_. Backups are hosted on
+  several remote servers as unencrypted database dumps; these backups can only be retrieved by
+  Odoo S.A. employees through support requests.
+
+- **Describe where your organization monitors and detects malicious activity in your
+  application(s).**
+
+  Odoo Online uses automated probes on our server that report their status in Munin, an opensource
+  monitoring tool. This tool automatically triggers alarms when probes detect values outside of
+  their pre-defined range. We monitor (among many other things) access rates, response times, ssh
+  connections, network activity.
+
+- **Describe how your organization's incident response plan addresses database hacks, unauthorized
+  access, and data leaks (a link to your policy is also acceptable).**
+
+  [Description of your organization's incident response plan]

--- a/sales/sale_amazon/manage.rst
+++ b/sales/sale_amazon/manage.rst
@@ -12,25 +12,27 @@ and **Canceled** orders are fetched. For **FBM** (Fulfilled by Merchant), the sa
 **Unshipped** and **Canceled** orders. For each synchronized order, a sales order and a customer are
 created in Odoo if they are not yet registered.
 
-.. note :: If you did not request access to Personally Identifiable Information of your customers
-           in the `Developer Registration and Assessment form <setup.html#developer-form>`_, the
-           customers are created anonymously (the name, postal address and phone number are omitted)
-           and named **Amazon Customer**.
+.. note::
+   If you did not request access to Personally Identifiable Information of your customers in the
+   :ref:`Developer Registration and Assessment form <amazon/developer-form>`, the customers are
+   created anonymously (the name, postal address and phone number are omitted) and named
+   **Amazon Customer**.
 
 When an order is canceled in Amazon and was already synchronized in Odoo, the corresponding sales
 order is canceled in Odoo.
 When an order is canceled in Odoo, a notification is sent to Amazon who will mark it as such in
 Seller Central and notify the customer.
 
-.. note :: To force the synchronization of an order whose status has not changed since the last
-           synchronization, activate the **Developer mode**, navigate to your Amazon account and
-           modify the date under :menuselection:`Orders Follow-up --> Last Order Sync`. Pick a date
-           anterior to the last status change of the order that you wish to synchronize and save.
+.. note::
+   To force the synchronization of an order whose status has not changed since the last
+   synchronization, activate the **Developer mode**, navigate to your Amazon account and modify the
+   date under :menuselection:`Orders Follow-up --> Last Order Sync`. Pick a date anterior to the
+   last status change of the order that you wish to synchronize and save.
 
-.. tip :: To synchronize immediately the orders of your Amazon account, open that later's form in
-          **Developer mode** and click the button **SYNC ORDERS**. The same can be done with order
-          cancellations and pickings by clicking the buttons **SYNC CANCELLATIONS** and **SYNC
-          PICKINGS**.
+.. tip::
+   To synchronize immediately the orders of your Amazon account switch to **Developer mode**, head
+   to your Amazon account and click the button **SYNC ORDERS**. The same can be done with order
+   cancellations and pickings by clicking the buttons **SYNC CANCELLATIONS** and **SYNC PICKINGS**.
 
 Manage deliveries in FBM
 ========================
@@ -51,17 +53,18 @@ in :menuselection:`Inventory --> Reporting --> Product Moves`. They pick up prod
 inventory location called **Amazon**. This location represents your stock in Amazon's warehouses
 and allows you to manage the stock of your products under the FBA program.
 
-.. tip :: To follow your Amazon (FBA) stock in Odoo, you can make an inventory adjustment after
-          replenishing it. You can also trigger an automated replenishment from reordering rules
-          on the Amazon location.
+.. tip::
+   To follow your Amazon (FBA) stock in Odoo, you can make an inventory adjustment after
+   replenishing it. You can also trigger an automated replenishment from reordering rules on the
+   Amazon location.
 
-.. tip :: The Amazon location is configurable by Amazon account managed in Odoo. All accounts of
-          the same company use the same location by default. It is however possible to follow the
-          stock by marketplace. First, remove the marketplace for which you want to follow the stock
-          separately from the list of synchronized marketplaces. Then, create another registration
-          for this account and remove all marketplaces, except the one to isolate from the others.
-          Finally, assign another stock location to the second registration of your account.
-
+.. tip::
+   The Amazon location is configurable by Amazon account managed in Odoo. All accounts of the same
+   company use the same location by default. It is however possible to follow the stock by
+   marketplace. First, remove the marketplace for which you want to follow the stock separately from
+   the list of synchronized marketplaces. Then, create another registration for this account and
+   remove all marketplaces, except the one to isolate from the others. Finally, assign another stock
+   location to the second registration of your account.
 
 Issue invoices and register payments
 ====================================
@@ -70,8 +73,9 @@ You can issue invoices for Amazon orders in Odoo. Click **Create Invoice** in th
 so. You can also do it in batch from the list view of orders. Then, confirm and send the invoices to
 your customers.
 
-.. tip :: To display only Amazon-related orders on the list view, you can filter orders based on the
-          sales team.
+.. tip::
+   To display only Amazon-related orders on the list view, you can filter orders based on the sales
+   team.
 
 As the customer has paid Amazon as an intermediary, you should register invoice payments in a
 payment journal dedicated to Amazon (e.g. Amazon Payments, with a dedicated intermediary account).
@@ -89,8 +93,9 @@ team is shared between all of your company's accounts.
 If you wish, you can change the sales team on your account for another to perform a separate
 reporting for the sales of this account.
 
-.. tip :: It is also possible to perform reporting on a per-marketplace basis in a similar fashion.
-          First, remove the marketplace you wish to track separately from the list of synchronized
-          marketplaces. Then, create another registration for this account and remove all
-          marketplaces, except the one to isolate from the others. Finally, assign another sales
-          team to one of the two registrations of your account.
+.. tip::
+   It is also possible to perform reporting on a per-marketplace basis in a similar fashion. First,
+   remove the marketplace you wish to track separately from the list of synchronized marketplaces.
+   Then, create another registration for this account and remove all marketplaces, except the one to
+   isolate from the others. Finally, assign another sales team to one of the two registrations of
+   your account.

--- a/sales/sale_amazon/setup.rst
+++ b/sales/sale_amazon/setup.rst
@@ -1,32 +1,6 @@
-======================================
-Configure Amazon MWS Connector in Odoo
-======================================
-
-Get your Amazon MWS Credentials
-===============================
-
-In order to integrate Amazon with Odoo, a seller account on professional selling plan is required.
-
-.. Anchor should be one paragraph below but is placed here to fix wrongly adjusted display
-.. _developer-form:
-
-Visit the `Amazon Marketplace Web Service documentation
-<http://docs.developer.amazonservices.com/en_US/dev_guide/DG_Registering.html>`_ and follow the
-instructions to register as a developer.
-
-Fill the Developer Registration and Assessment form as suggested below and provide your own contact
-information in the **Developer contact information** section. For the other sections, take care to
-adapt your responses accordingly to your business case. In particular, select the correct region of
-your seller account and uncheck the **Merchant Fulfilled Shipping** function if you plan to sell
-exclusively with the Fulfillment by Amazon service.
-
-.. warning :: If you select the **Merchant Fulfilled Shipping** function (i.e. you request access to
-              Personally Identifiable Information (PII) of your customers), Amazon may request you
-              to fill out a second form, depending on the data protection policy in the region of
-              your seller account (e.g. GDPR in Europe).
-
-.. image:: ./media/dev_form.png
-
+==================================
+Configure Amazon Connector in Odoo
+==================================
 
 Register your Amazon account in Odoo
 ====================================
@@ -39,14 +13,14 @@ The **Seller ID** can be found in Seller Central under the link **Your Merchant 
 Developer Central (where the Developer Registration and Assessment form was located).
 
 Once the account is registered, the marketplaces available to this account are synchronized and
-listed under the **Marketplaces** tab. If you wish, you can remove some from the list of
+listed under the **Marketplaces** tab. If you wish, you can remove some items from the list of
 synchronized marketplaces to disable their synchronization.
 
-Match database products in Amazon orders
-========================================
+Match database products in Amazon
+=================================
 
 .. Anchor should be one paragraph below but is placed here to fix wrongly adjusted display
-.. _matching:
+.. _amazon/matching:
 
 When an Amazon order is synchronized, up to three sales order items are created in Odoo for each
 product sold on Amazon: one for the marketplace product, one for the shipping charges (if any) and
@@ -56,23 +30,25 @@ The selection of a database product for a sales order item is done by matching i
 **internal reference** with the **SKU** for marketplace items, the **shipping code** for delivery
 charges, and the **gift wrapping** code for gift wrapping charges.
 
-For marketplace products, matchings are saved as **Amazon Offers** which are listed under the
-**Offers** stat button on the account form. Offers are automatically created when the matching is
+For marketplace products, pairings are saved as **Amazon Offers** which are listed under the
+**Offers** stat button on the account form. Offers are automatically created when the pairing is
 established and are used for subsequent orders to lookup SKUs. If no offer with a matching SKU is
-found, :ref:`the internal reference is used instead <matching>`.
+found, :ref:`the internal reference is used instead <amazon/matching>`.
 
-.. tip :: It is possible to force the matching of a marketplace item with a specific product by
-          changing either the product or the SKU of an offer. The offer can be manually created if
-          it was not automatically done yet. This is useful if you do not use the internal
-          reference as the SKU or if you sell the product under different conditions.
+.. tip::
+   It is possible to force the pairing of a marketplace item with a specific product by changing
+   either the product or the SKU of an offer. The offer can be manually created if it was not
+   automatically done yet. This is useful if you do not use the internal reference as the SKU or if
+   you sell the product under different conditions.
 
 If no database product with a matching internal reference is found for a given SKU or gift wrapping
 code, a default database product **Amazon Sale** is used. The same is done with the default product
 **Amazon Shipping** and the shipping code.
 
-.. note :: To modify the default products, activate the **Developer mode** and navigate to
-           :menuselection:`Sales --> Configuration --> Settings --> Connectors --> Amazon Sync -->
-           Default Products`.
+.. note::
+   To modify the default products, activate the **Developer mode** and navigate to
+   :menuselection:`Sales --> Configuration --> Settings --> Connectors --> Amazon Sync -->
+   Default Products`.
 
 Configure taxes of products
 ===========================
@@ -82,6 +58,7 @@ those set on the product or determined by the fiscal position. Make sure to have
 taxes on your products in Odoo or to have it done by a fiscal position, to avoid discrepancies in
 the subtotals between Seller Central and Odoo.
 
-.. note :: As Amazon does not necessarily apply the same taxes as those configured in Odoo, it may
-           happen that order totals differ by a few cents from that on Seller Central. Those
-           differences can be resolved with a write-off when reconciling the payments in Odoo.
+.. note::
+   As Amazon does not necessarily apply the same taxes as those configured in Odoo, it may happen
+   that order totals differ by a few cents from that on Seller Central. Those differences can be
+   resolved with a write-off when reconciling the payments in Odoo.


### PR DESCRIPTION
…urity standards

Depending on whether the seller made a request to get access to Personally Identifiable Information of its customers, and on other factors, Amazon may require him to fill out a second form about his data protection policy.
This commit makes it clear that compliance with Amazon's security standards is not guaranteed if the seller applying for Amazon MWS access keys is hosted on Odoo (SaaS or .sh).

Additionally, it add a section in which the questions asked to Amazon sellers are listed and answered for the Odoo Online and Odoo.sh platforms.