### PR TITLE
[FIX] rendering of tables with merged cells

### DIFF
--- a/_extensions/odoo/translator.py
+++ b/_extensions/odoo/translator.py
@@ -433,7 +433,12 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
             tagname = 'th'
         else:
             tagname = 'td'
-        self.body.append(self.starttag(node, tagname))
+        attrs = {}
+        if 'morerows' in node:
+            attrs['rowspan'] = node['morerows']+1
+        if 'morecols' in node:
+            attrs['colspan'] = node['morecols']+1
+        self.body.append(self.starttag(node, tagname, **attrs))
         self.context.append(tagname)
     def depart_entry(self, node):
         self.body.append(u'</{}>'.format(self.context.pop()))


### PR DESCRIPTION
Merged cells in the first columns were not rendered correctly and values from
other columns would be placed in the wrong columns.

6698bff6 moved in this PR from #554 to handle this starting from 11.0