### PR TITLE
Update path to default terms and conditions from Sales to Accounting within documentation.

### DIFF
--- a/sales/invoicing/subscriptions.rst
+++ b/sales/invoicing/subscriptions.rst
@@ -9,7 +9,7 @@ Make a subscription from a sales order
 ======================================
 
 From the sales app, create a quotation to the desired customer, and
-select the subscription product your previously created.
+select the subscription product your previously created from the Subscriptions App.
 
 When you confirm the sale the subscription will be created
 automatically. You will see a direct link from the sales order to the

--- a/sales/send_quotations/terms_and_conditions.rst
+++ b/sales/send_quotations/terms_and_conditions.rst
@@ -14,7 +14,7 @@ quotation, sales order and invoice.
 Set up your default terms and conditions
 ========================================
 
-Go to :menuselection:`SALES --> Configuration --> Settings` and activate
+Go to :menuselection:`Accounting --> Configuration --> Settings` and activate
 *Default Terms & Conditions*.
 
 .. image:: media/terms_and_conditions01.png 


### PR DESCRIPTION
Change **Go to SALES ‣ Configuration ‣ Settings and activate Default Terms & Conditions.** to **Go to Accounting ‣ Settings and activate Default Terms & Conditions** This is due to the fact that in V13 the Default Terms & Conditions setting is no longer available in under Sales but rather Accounting in the General Settings as well. 