### PR TITLE
update time_materials.rst to reflect correct path to Analytic Accounting in settings. 

### DIFF
--- a/sales/invoicing/time_materials.rst
+++ b/sales/invoicing/time_materials.rst
@@ -67,7 +67,7 @@ To track & invoice expenses, you will need the expenses app. Go to
 :menuselection:`Apps --> Expenses` to install it.
 
 You should also activate the analytic accounts feature to link expenses
-to the sales order, to do so, go to :menuselection:`Invoicing -->
+to the sales order, to do so, go to :menuselection:`Accounting -->
 Configuration --> Settings` and activate *Analytic Accounting*.
 
 Add expenses to your sales order


### PR DESCRIPTION
Change *Invoicing --> Configuration --> Settings` and activate *Analytic Accounting*.** to **:`Accounting --> Configuration --> Settings` and activate *Analytic Accounting.** This is due to the fact that in V13 the Analytic Accounting setting is no longer available in under but rather Accounting in the General Settings as well.