### PR TITLE
[FIX] redirects: add redirections to {amazon,ebay}_connector

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -34,3 +34,10 @@
 
 # Redirections introduced in 13.0 :
 
+sales/sale_amazon.rst sales/amazon_connector.rst                # sale_amazon -> amazon_connector (#524)
+sales/sale_amazon/apply.rst sales/amazon_connector/apply.rst    # sale_amazon/* -> amazon_connector/* (#524)
+sales/sale_amazon/setup.rst sales/amazon_connector/setup.rst    # sale_amazon/* -> amazon_connector/* (#524)
+sales/sale_amazon/manage.rst sales/amazon_connector/manage.rst  # sale_amazon/* -> amazon_connector/* (#524)
+sales/sale_ebay.rst sales/ebay_connector.rst                    # sale_ebay -> ebay_connector (#524)
+sales/ebay/setup.rst sales/ebay_connector/setup.rst             # ebay/* moved to ebay_connector/* (#524)
+sales/ebay/manage.rst sales/ebay_connector/manage.rst           # ebay/* moved to ebay_connector/* (#524)


### PR DESCRIPTION
This commit adds redirections to files moved in odoo/documentation-user#524 (13.0):

- sales/sale_amazon.rst moved to sales/amazon_connector.rst
- sales/sale_amazon/apply.rst moved to sales/amazon_connector/apply.rst
- sales/sale_amazon/setup.rst moved to sales/amazon_connector/setup.rst
- sales/sale_amazon/manage.rst moved to sales/amazon_connector/manage.rst
- sales/sale_ebay.rst moved to sales/ebay_connector.rst
- sales/ebay/setup.rst moved to sales/ebay_connector/setup.rst
- sales/ebay/manage.rst moved to sales/ebay_connector/manage.rst