### PR TITLE
[FIX] redirects: add a redirection to contributing

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -30,3 +30,4 @@
 
 # Redirections introduced in 12.0 :
 
+support/user_doc.rst contributing/documentation/introduction_guide.rst  # removed in forward-port of #544 (b109c3af)


### PR DESCRIPTION
This commit adds a redirection for files removed in b109c3af (12.0)
following #544 (11.0):

- support/user_doc.rst replaced by contributing/documentation/introduction_guide.rst