### PR TITLE
[FIX] accounting: missing redirect for a mid-menu page

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -70,6 +70,7 @@ accounting/others/reporting/customize.rst accounting/reporting/overview/customiz
 accounting/others/reporting/main_reports.rst accounting/reporting/overview/main_reports.rst                       # others/reporting/* --> reporting/overview/*
 accounting/fiscality/taxes/tax_returns.rst accounting/reporting/declarations/tax_returns.rst                      # fiscality/taxes/* --> reporting/declarations/*
 accounting/bank/setup/create_bank_account.rst accounting/bank/setup/bank_accounts.rst                             # create_bank_account -> bank_accounts
+accounting/localizations.rst accounting/fiscal_localizations/localizations.rst                                    # localizations --> fiscal_localizations/localizations
 accounting/localizations/argentina.rst accounting/fiscal_localizations/localizations/argentina.rst                # localizations/* --> fiscal_localizations/localizations/*
 accounting/localizations/colombia.rst accounting/fiscal_localizations/localizations/colombia.rst                  # localizations/* --> fiscal_localizations/localizations/*
 accounting/localizations/colombia_ES.rst accounting/fiscal_localizations/localizations/colombia_ES.rst            # localizations/* --> fiscal_localizations/localizations/*


### PR DESCRIPTION
Accounting redirect
localizations --> fiscal_localizations/localizations