### PR TITLE
13.0-documentation-applications-order-jcs

### DIFF
--- a/accounting.rst
+++ b/accounting.rst
@@ -1,8 +1,8 @@
 :banner: banners/accounting.png
 
-==========
-Accounting
-==========
+========================
+Invoicing and Accounting
+========================
 
 .. toctree::
    :titlesonly:

--- a/applications.rst
+++ b/applications.rst
@@ -2,36 +2,79 @@
 Applications
 ============
 
-.. toctree::
-   :titlesonly:
-
-   accounting
-   expense/expense
+.. ORDER (new apps / sections included):
+   general
+   discuss
    crm
    sales
-   website
-   live_chat
-   ecommerce
    purchase
+   rental
+   accounting
+   consolidation
+   subscription
+   project
+   timesheets
+   planning
+   bi
+   documents
+   fsm
+   point_of_sale
    inventory
    manufacturing
    quality
-   point_of_sale
-   discuss
-   helpdesk
-   project
-   fsm
-   planning
-   timesheets
+   barcode
    iot
-   mobile/firebase
-   events
+   website
+   ecommerce
+   elearning
+   helpdesk
+   live_chat
    email_marketing
    social_marketing
    sms_marketing
    marketing_automation
+   events
    survey
+   employees
+   recruitment
+   referrals
+   leaves
+   expenses
+   appraisals
+   fleet
+   approvals
+   lunch
+   studio
+   mobile
+   misc
+
+.. toctree::
+   :titlesonly:
 
    general
-
-.. Leave general on the last line !
+   discuss
+   crm
+   sales
+   purchase
+   accounting
+   project
+   timesheets
+   planning
+   fsm
+   point_of_sale
+   inventory
+   manufacturing
+   quality
+   iot
+   website
+   ecommerce
+   helpdesk
+   live_chat
+   email_marketing
+   social_marketing
+   sms_marketing
+   marketing_automation
+   events
+   survey
+   expense/expense
+   mobile/firebase


### PR DESCRIPTION
This PR has two commits

- [IMP] documentation: reorder the main apps' list
  - Reorders the list as requested by @AntoineVDV and defined by the marketing team.
- [REF] doc: modify toctrees for expenses and mobile to unify it with the rest of the doc
  - is merely a suggestion to have the same toctree even for apps that currently have only one doc.
  - redirects `expense/expense` to `expenses/expenses`
