### PR TITLE
[IMP] odoo_sh: clarify dev branch behavior

### DIFF
--- a/odoo_sh/getting_started/branches.rst
+++ b/odoo_sh/getting_started/branches.rst
@@ -101,7 +101,7 @@ Similar to staging branches, the emails are not sent but are intercepted by a ma
 scheduled actions are not triggered as often is the database is not in use.
 
 The databases created for development branches are meant to live around three days.
-After that, they can be garbage collected to make room for new databases.
+After that, they can be automatically garbage collected to make room for new databases without prior notice.
 
 .. _odoosh-gettingstarted-branches-mergingbranches:
 


### PR DESCRIPTION
Some users have reported that current wording sets the expectation that there will be a notification when dev branches will be eliminated after the three days. This makes it clear that after 3 days dev branches are automatically garbage collected at any moment without prior notice.