### PR TITLE
[IMP] discuss: delete redirection for mail_twitter.rst

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -156,7 +156,6 @@ ecommerce/shopper_experience/wire_transfer.rst general/payment_acquirers/wire_tr
 
 discuss/monitoring.rst discuss/overview/get_started.rst                    # (#655)
 discuss/mentions.rst discuss/overview/get_started.rst                      # (#655)
-discuss/mail_twitter.rst discuss/overview/get_started.rst                  # (#655)
 discuss/tracking.rst project/tasks/collaborate.rst                         # (#655)
 discuss/email_servers.rst discuss/advanced/email_servers.rst               # (#655)
 discuss/plan_activities.rst discuss/overview/plan_activities.rst           # (#655)


### PR DESCRIPTION
The redirection discuss/mail_twitter.rst discuss/overview/get_started.rst # was deleted.