### PR TITLE
[FIX] expense: Reference in first position in email subject

### DIFF
--- a/expense/expense.rst
+++ b/expense/expense.rst
@@ -81,8 +81,8 @@ For security purposes, only authenticated employee emails
 
 .. tip::
     The expense product is set automatically if the mail subject contains 
-    the product's internal reference between brackets (e.g. [Food]). 
-    Type the expense amount in the mail subject to set it on the expense too.
+    the product's internal reference in first position.
+    Type the expense amount in the mail subject to set it on the expense too (e.g. Ref001 Food 100€).
 
 How to submit expenses to managers
 ==================================


### PR DESCRIPTION
As commited here: 

https://github.com/odoo/odoo/commit/4ba8f51d87be394988e6e2889cf03f351afea1a0

The reference must be in first position in the email subject.

https://github.com/odoo/odoo/blob/13.0/addons/hr_expense/models/hr_expense.py#L568

opw:2255175