### PR TITLE
[ADD] support for meta directive

### DIFF
--- a/_extensions/odoo/layout.html
+++ b/_extensions/odoo/layout.html
@@ -1,4 +1,5 @@
 {% extends "basic/layout.html" %}
+{% set html5_doctype = True %}
 
 {% set classes = [] %}
 {% if pagename == master_doc %}
@@ -12,15 +13,6 @@
 {% if 'classes' in meta %}
   {% set classes = classes + meta['classes'].split() %}
 {% endif %}
-
-{%- block doctype -%}
-  <!doctype html>
-{%- endblock -%}
-{%- block htmltitle -%}
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  {{ super() }}
-{%- endblock -%}
 
 {%- block linktags -%}
   {% for code, url in language_codes %}

--- a/_extensions/odoo/translator.py
+++ b/_extensions/odoo/translator.py
@@ -36,10 +36,6 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
     html_subtitle = 'html_subtitle'
 
     # <meta> tags
-    meta = [
-        '<meta http-equiv="X-UA-Compatible" content="IE=edge">',
-        '<meta name="viewport" content="width=device-width, initial-scale=1">'
-    ]
 
     def __init__(self, document, builder):
         # order of parameter swapped between Sphinx 1.x and 2.x, check if
@@ -49,6 +45,11 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
 
         super(BootstrapTranslator, self).__init__(document)
         self.builder = builder
+        self.meta = [
+            '', '',
+            '\n    <meta http-equiv="X-UA-Compatible" content="IE=edge">',
+            '\n    <meta name="viewport" content="width=device-width, initial-scale=1">'
+        ]
         self.body = []
         self.fragment = self.body
         self.html_body = self.body
@@ -77,6 +78,9 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
             ord('>'): u'&gt;',
             0xa0: u'&nbsp;'
         })
+
+    def add_meta(self, meta):
+        self.meta.append('\n    ' + meta)
 
     def starttag(self, node, tagname, **attributes):
         tagname = tagname.lower()
@@ -132,6 +136,14 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
     def visit_document(self, node):
         self.first_title = True
     def depart_document(self, node):
+        pass
+
+    def visit_meta(self, node):
+        if node.hasattr('lang'):
+            node['xml:lang'] = node['lang']
+        meta = self.starttag(node, 'meta', **node.non_default_attributes())
+        self.add_meta(meta)
+    def depart_meta(self, node):
         pass
 
     def visit_section(self, node):


### PR DESCRIPTION
```rst
.. meta::
    :description: blah blah blah
    :keywords lang=en: x y z
```
will generate
```html
<meta name="description" content="blah blah blah">
<meta name="keywords" lang="en" content="x y z">
```
Also cleaned up `layout.html` a tad while at it:
* we're now properly setting the default metas via the translator so setting them in the template is unnecessary
* toggle the `html5_doctype` Sphinx flag as it... uses an HTML5 doctype so we don't need to do that by hand anymore (also uses a `charset` meta instead of an `http-equiv="Content-Type"` and suppresses sphinx's own `X-UA-Compatible`)