### PR TITLE
[FIX] Payment_authorize, Fix relay response URL

### DIFF
--- a/general/payment_acquirers/authorize.rst
+++ b/general/payment_acquirers/authorize.rst
@@ -81,7 +81,7 @@ Settings --> Transaction Response Settings --> Response/Receipt URLs`, and set t
 - | Default Receipt URL:
   | *https://[yourcompany.odoo.com]*/**payment/authorize/return**
 - | Default Relay Response URL:
-  | *https://[yourcompany.odoo.com]*/**payment/authorize/return**
+  | *https://[yourcompany.odoo.com]*/**shop/confirmation**
 
 .. note::
    | Failing to complete this step results in the following error:


### PR DESCRIPTION
For Authorize.net configuration, you need individual Receipt and Relay Response URL's.  The previous version featured the same URL twice.  The Relay Response URL here has been updated to reflect proper configuration.