### PR TITLE
[FIX] Remove api.multi which doesn't exist in 13.0

### DIFF
--- a/odoo_sh/getting_started/first_module.rst
+++ b/odoo_sh/getting_started/first_module.rst
@@ -477,7 +477,6 @@ Add
           values['name'] = unidecode(values['name'])
       return super(my_module, self).create(values)
 
-  @api.multi
   def write(self, values):
       if 'name' in values:
           values['name'] = unidecode(values['name'])


### PR DESCRIPTION
`api.multi` was removed in 13.0 and is the default behavior. Attempting
to use it in this tutorial will result in a build error.