### PR TITLE
[IMP] accounting: Warning about currency exchange entries

### DIFF
--- a/accounting/others/multicurrencies/exchange.rst
+++ b/accounting/others/multicurrencies/exchange.rst
@@ -105,6 +105,8 @@ journal entries. All the exchange rates differences are recorded in it.
 .. tip::
     The Exchange difference journal can be changed in your accounting settings.
 
+.. include:: full_reconcile_warning.rst
+
 .. seealso::
     * :doc:`../../bank/reconciliation/configure`
     * :doc:`../../bank/reconciliation/use_cases`

--- a/accounting/others/multicurrencies/full_reconcile_warning.rst
+++ b/accounting/others/multicurrencies/full_reconcile_warning.rst
@@ -1,0 +1,7 @@
+.. warning::
+    In order for an exchange difference entry to be created automatically, the
+    corresponding invoices and payments need to be fully reconciled. This means
+    the invoices are fully paid and the payments are fully spent on invoices.
+    If you partially pay 3 invoices from 2 payments, and the last invoice still
+    has an amount due, there will be no exchange difference entry for any of
+    them until that final amount is paid.

--- a/accounting/others/multicurrencies/how_it_works.rst
+++ b/accounting/others/multicurrencies/how_it_works.rst
@@ -165,6 +165,8 @@ journal entries. All the exchange rates differences are recorded in it.
 .. image:: media/works14.png
    :align: center
 
+.. include:: full_reconcile_warning.rst
+
 .. seealso::
 
 	* :doc:`invoices_payments`

--- a/accounting/others/multicurrencies/invoices_payments.rst
+++ b/accounting/others/multicurrencies/invoices_payments.rst
@@ -114,6 +114,8 @@ Difference** journal entries. All the exchange rates differences are recorded in
 .. image:: media/invoice09.png
    :align: center
 
+.. include:: full_reconcile_warning.rst
+
 .. seealso::
 	
 	* :doc:`how_it_works`


### PR DESCRIPTION
It's not really obvious that payments and invoices need to be fully
reconciled before their currency exchange entries get created, so this
is a warning about that.