### PR TITLE
[IMP] localization: add "webinars" section to Chile

### DIFF
--- a/accounting/fiscal_localizations/localizations/chile.rst
+++ b/accounting/fiscal_localizations/localizations/chile.rst
@@ -2,6 +2,13 @@
 Chile
 =====
 
+Webinars
+========
+
+Below you can find videos with a general description of the localization, and how to configure it.
+
+- `VIDEO WEBINAR OF A COMPLETE DEMO <https://youtu.be/BHnByZiyYcM>`_.
+
 Introduction
 ============
 


### PR DESCRIPTION
l10n_cl (Chile):

The change is due to a request to add webinars we had per localization to improve the visibility of this as a tool both for customers and Odooers. Why at the beginning? This is because is the first thing you see when accessing the documentation.

This is a minor change.