### PR TITLE
[ADD] Minor change - Webinars on top

### DIFF
--- a/accounting/fiscal_localizations/localizations/argentina.rst
+++ b/accounting/fiscal_localizations/localizations/argentina.rst
@@ -2,6 +2,13 @@
 Argentina
 =========
 
+Webinars
+========
+Below you can find videos with a general description of the localization and how to configure it.
+
+- This is a V13 video, there aren't major changes in the workflow and configuration 
+  compared to V14 `VIDEO WEBINAR OF A COMPLETE DEMO <https://youtu.be/c41-8cVaYAI>`_.
+
 Introduction
 ============
 


### PR DESCRIPTION
L10n_ar (Argentina):

The change is due to a request to add webinars we had per localization to improve the visibility of this as a tool both for customers and Odooers. Why at the beginning? This is because is the first thing you see when accessing the documentation.

This is a minor change.