### PR TITLE
[ADD] Minor change - Webinars on top l10n_ar

### DIFF
--- a/accounting/fiscal_localizations/localizations/argentina.rst
+++ b/accounting/fiscal_localizations/localizations/argentina.rst
@@ -2,6 +2,13 @@
 Argentina
 =========
 
+Webinars
+========
+Below you can find videos with a general description of the localization, how to configure it and 
+what changes were made for version 13.
+
+- `VIDEO WEBINAR OF A COMPLETE DEMO <https://youtu.be/c41-8cVaYAI>`_.
+
 Introduction
 ============
 


### PR DESCRIPTION
l10n_ar (Argentina):

The change is due to a request to add webinars we had per localization to improve the visibility of this as a tool both for customers and Odooers. Why at the beginning? This is because is the first thing you see when accessing the documentation.

This is a minor change.