### PR TITLE
[IMP] accounting: mexico - MXN as default currency

### DIFF
--- a/accounting/localizations/mexico.rst
+++ b/accounting/localizations/mexico.rst
@@ -81,6 +81,12 @@ company’s contact.
 .. image:: media/mexico03.png
    :align: center
 
+.. warning::
+   From a legal point of view, a Mexican company must use the local currency (MXN).
+   Therefore, Odoo does not provide features to manage an alternative configuration.
+   If you want to manage another currency, let MXN be the default currency and use
+   price list instead.
+
 4. Set the proper "Fiscal Position" on the partner that represent the company
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
A Mexican company should keep MXN as default company. This is actually a
legal obligation.