### PR TITLE
[FIX] purchase: create redirects for moved, deleted and merged docs

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -186,3 +186,9 @@ purchase/purchases/tender/call_for_tender.rst purchase/manage_deals/agreements.r
 
 purchase/purchases/rfq/3_way_matching.rst purchase/manage_deals/control_bills.rst  # (#829)
 purchase/purchases/rfq/bills.rst purchase/manage_deals/control_bills.rst      # (#829)
+
+purchase/purchases/master/uom.rst purchase/products/uom.rst											# (#814)
+purchase/replenishment/flows/compute_date.rst inventory/management/planning/scheduled_dates.rst		# (#814)
+purchase/replenishment/flows/purchase_triggering.rst purchase/products/reordering.rst				# (#814)
+purchase/replenishment/flows/setup_stock_rule.rst purchase/products/reordering.rst					# (#814)
+purchase/replenishment/multicompany/setup.rst general/multi_companies/manage_multi_companies.rst	# (#814)


### PR DESCRIPTION
With the introduction of V14, all the easy flows to be removed to avoid an
increasing technical debt. For purchase, approximately 2/3 of the pages were
removed, which meant that a reorganisation and simplification of the structure
was necessary. A couple of removed docs now point out to docs under other apps
to avoid duplicating the information.