### PR TITLE
[REM] odoo_sh: remove incorrect information about cups

### DIFF
--- a/odoo_sh/advanced/frequent_technical_questions.rst
+++ b/odoo_sh/advanced/frequent_technical_questions.rst
@@ -31,15 +31,3 @@ We advise that:
   `idempotent <https://stackoverflow.com/a/1077421/3332416>`_: they must not
   cause side-effects if they are started more often than expected.
 
-
-Can you install `pycups <https://pypi.org/project/pycups/>`_ or some similar library linked to `CUPS <https://www.cups.org/>`_ ?
---------------------------------------------------------------------------------------------------------------------------------
-
-Several community apps for Odoo list ``pycups`` as required dependency.
-
-- ``pycups`` is a set of Python bindings for the libcups library. They are meant to integrate your computer with a local printing server.
-- CUPS is a printing server meant to be used for printers on the same local network as the Odoo server.
-
-We consider adding new system packages as long as they are indeed used.
-Regarding ``pycups``, you won't be able to configure a printer in the local network of your Odoo.sh server.
-


### PR DESCRIPTION
CUPS the server will never be installed on an Odoo.sh machine.
That being said you can use a remote printer with a cups client.
The problem lays in the sorry state of libcups dependencies so we will
try to get a reliable section in the documentation for 20.04 as soon as
we can get a testcase.

Meanwhile, it has been reported that the command line `lp` cups cli
client tool could be used as a workaround in the OCA concerned module:

https://gist.github.com/rm-jamotion/0453e91ff3e13350a1e46a11ebb02e8d

Reapply of https://github.com/odoo/documentation-user/commit/3b4c795